### PR TITLE
Remove plus button on contacts and cited responsibility

### DIFF
--- a/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/config-view/config-view-dataset.xml
+++ b/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/config-view/config-view-dataset.xml
@@ -7,7 +7,7 @@
 	xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/1.0"
 	xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
 	xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/1.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
-	
+
 	<sidePanel>
         <directive data-gn-validation-report=""/>
         <directive data-gn-onlinesrc-list=""/>
@@ -18,18 +18,18 @@
         <!-- <directive data-gn-suggestion-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/> -->
     </sidePanel>
-    
+
 	<tab id="resourceDescription" default="true" mode="flat">
 		<section name=" ">
 			<!-- special template to render this field readonly - see layout-custom-fields.xsl -->
 			<field xpath="/mdb:MD_Metadata/mdb:alternativeMetadataReference" />
-		
-			<field name="PID" 
+
+			<field name="PID"
 			xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:identifier[1]/mcc:MD_Identifier/mcc:code" />
-						
-			<field name="DOI" 
+
+			<field name="DOI"
 			xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:identifier[2]/mcc:MD_Identifier/mcc:code" />
-					
+
 			<field
 				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:title" />
 			<field
@@ -183,14 +183,14 @@
 	<!-- <tab id="resourceLineageTab" mode="flat">
 		<section name=" ">
 			<field
-				xpath="/mdb:MD_Metadata/mdb:resourceLineage/mrl:LI_Lineage/mrl:statement" /> 
+				xpath="/mdb:MD_Metadata/mdb:resourceLineage/mrl:LI_Lineage/mrl:statement" />
 		</section>
 	</tab> -->
 
 	<tab id="resourceFormat" mode="flat">
 		<section name=" ">
 			<field
-				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:resourceFormat/mrd:MD_Format/mrd:formatSpecificationCitation/cit:CI_Citation/cit:onlineResource/cit:CI_OnlineResource/cit:linkage" /> 
+				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:resourceFormat/mrd:MD_Format/mrd:formatSpecificationCitation/cit:CI_Citation/cit:onlineResource/cit:CI_OnlineResource/cit:linkage" />
 		</section>
 	</tab>
 
@@ -199,9 +199,9 @@
 	<flatModeExceptions>
 		<for name="cit:date" />
 		<for name="mri:descriptiveKeywords" />
-		<for name="cit:party" />
+<!--		<for name="cit:party" />-->
 		<for name="cit:CI_Individual" />
 		<for name="cit:CI_Organisation" />
 		<for name="mrl:LI_Lineage" />
 	</flatModeExceptions>
-</view>	
+</view>

--- a/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/config-view/config-view-service.xml
+++ b/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/config-view/config-view-service.xml
@@ -8,7 +8,7 @@
 	xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/1.0"
 	xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
 	xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/1.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
-	
+
 	<sidePanel>
         <directive data-gn-validation-report=""/>
         <directive data-gn-onlinesrc-list=""/>
@@ -19,18 +19,18 @@
         <!-- <directive data-gn-suggestion-list=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/> -->
     </sidePanel>
-    
+
 	<tab id="resourceDescription" default="true" mode="flat">
 		<section name=" ">
 			<field xpath="/mdb:MD_Metadata/mdb:alternativeMetadataReference" />
-			
-			<field name="PID" 
+
+			<field name="PID"
 			xpath="/mdb:MD_Metadata/mdb:identificationInfo/srv:SV_ServiceIdentification/mri:citation/cit:CI_Citation/cit:identifier[1]/mcc:MD_Identifier/mcc:code" />
-						
-			<field name="DOI" 
+
+			<field name="DOI"
 			xpath="/mdb:MD_Metadata/mdb:identificationInfo/srv:SV_ServiceIdentification/mri:citation/cit:CI_Citation/cit:identifier[2]/mcc:MD_Identifier/mcc:code" />
-			
-			
+
+
 			<field
 				xpath="/mdb:MD_Metadata/mdb:identificationInfo/srv:SV_ServiceIdentification/mri:citation/cit:CI_Citation/cit:title" />
 			<field
@@ -201,7 +201,7 @@
 	<tab id="distribution" mode="flat">
 		<section name=" ">
 			<field xpath="/mdb:MD_Metadata/mdb:distributionInfo" />
-			<!-- <text ref="useAssociatedResources" if="count(mdb:MD_Metadata/mdb:distributionInfo/*) 
+			<!-- <text ref="useAssociatedResources" if="count(mdb:MD_Metadata/mdb:distributionInfo/*)
 				= 0"/> -->
 			<text ref="useAssociatedResources" />
 		</section>
@@ -212,7 +212,6 @@
 	<flatModeExceptions>
 		<for name="cit:date" />
 		<for name="mri:descriptiveKeywords" />
-		<for name="cit:party" />
 		<for name="cit:CI_Individual" />
 		<for name="cit:CI_Organisation" />
 		<for name="mrl:LI_Lineage" />

--- a/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/config-view/config-view-source.xml
+++ b/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/config-view/config-view-source.xml
@@ -8,7 +8,7 @@
 	xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/1.0"
 	xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
 	xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/1.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
-	
+
 	<sidePanel>
             <directive data-gn-validation-report=""/>
             <directive data-gn-onlinesrc-list=""/>
@@ -19,12 +19,12 @@
             <!-- <directive data-gn-suggestion-list=""/>
             <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/> -->
         </sidePanel>
-    
+
 	<tab id="resourceDescription" default="true" mode="flat">
 		<section name=" ">
 			<!-- special template to render this field readonly - see layout-custom-fields.xsl -->
 			<field xpath="/mdb:MD_Metadata/mdb:alternativeMetadataReference" />
-			<field name="PID" 
+			<field name="PID"
 			xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:identifier[1]/mcc:MD_Identifier/mcc:code" />
 			<field
 				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:title" />
@@ -33,7 +33,7 @@
 			<field
 				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:purpose" />
 			<field
-				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:status" />	
+				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:status" />
 			<field
 				xpath="/mdb:MD_Metadata/mdb:resourceLineage/mrl:LI_Lineage/mrl:statement" />
 		</section>
@@ -48,7 +48,7 @@
 			<field
 				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:citedResponsibleParty"
 				or="citedResponsibleParty"
-				in="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation" />		
+				in="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation" />
 		</section>
 	</tab>
 
@@ -117,16 +117,15 @@
 	<tab id="resourceFormat" mode="flat">
 		<section name=" ">
 			<field
-				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:resourceFormat/mrd:MD_Format/mrd:formatSpecificationCitation/cit:CI_Citation/cit:onlineResource/cit:CI_OnlineResource/cit:linkage" /> 
+				xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:resourceFormat/mrd:MD_Format/mrd:formatSpecificationCitation/cit:CI_Citation/cit:onlineResource/cit:CI_OnlineResource/cit:linkage" />
 		</section>
 	</tab>
-	
-	
+
+
 	<!-- Elements that should not use the "flat" mode -->
 	<flatModeExceptions>
 		<for name="cit:date" />
 		<for name="mri:descriptiveKeywords" />
-		<for name="cit:party" />
 		<for name="cit:CI_Individual" />
 		<for name="cit:CI_Organisation" />
 		<for name="mrl:LI_Lineage" />


### PR DESCRIPTION
Remove the plus drop menu button to access the contacts and cited responsibility 'contacts list.

Ref. GeoCat#417548

Previously:
![plusButtonEditor2](https://user-images.githubusercontent.com/826920/87436663-9ec73d80-c5ed-11ea-8838-837584bb7858.JPG)
![plusButtonEditor](https://user-images.githubusercontent.com/826920/87436665-9ff86a80-c5ed-11ea-9d40-f0b9d8da5cab.JPG)

After this Pull Request:

![image](https://user-images.githubusercontent.com/826920/87436775-c6b6a100-c5ed-11ea-8849-363e1f159cff.png)
![image](https://user-images.githubusercontent.com/826920/87436819-d6ce8080-c5ed-11ea-8f36-c3c72422e3ea.png)

