### PR TITLE
[BP] Fix for the `none` background image causing a 404

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -29,10 +29,10 @@ html, body {
 //
 // if the background image is an empty string it will be substitued with the name of the css file,
 // see: https://stackoverflow.com/questions/20727262/css-file-considered-as-being-an-image-resource
-[ng-app^="gn_search_"] body when not (@gn-background-image = "") {
+[ng-app^="gn_search_"] body when (isstring(@gn-background-image)) {
   background-image: url(@gn-background-image);
 }
-[ng-app^="gn_login"] body when not (@gn-background-image = "") {
+[ng-app^="gn_login"] body when (isstring(@gn-background-image)) {
   background-image: url(@gn-background-image);
 }
 


### PR DESCRIPTION
Backport of geonetwork/core-geonetwork#4558

Fixes this error:
```
2020-04-14 22:32:28,053 ERROR [ro.isdc.wro.http.WroFilter] - Exception occured
ro.isdc.wro.WroRuntimeException: Cannot build valid CacheKey from request: /geonetwork/static/none
```

Ref. GeoCat#687176