### PR TITLE
Once an cited responsible or contact has been added - make fields not editable

### DIFF
--- a/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/layout-custom-fields.xsl
+++ b/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/layout-custom-fields.xsl
@@ -48,7 +48,7 @@
     </xsl:call-template>
 
   </xsl:template>
-  
+
   <xsl:template mode="mode-iso19115-3"
                 match="mdb:alternativeMetadataReference[cit:CI_Citation/cit:identifier/mcc:MD_Identifier/mcc:codeSpace/gco:CharacterString='eCatId']"
                 priority="2000">
@@ -363,7 +363,7 @@
     <xsl:apply-templates mode="mode-iso19115-3" select="*"/>
   </xsl:template>
 
-  
+
   <!--
     Display contact as table when mode is flat (eg. simple view) or if using xsl mode
     Match first node (or added one)

--- a/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/layout.xsl
+++ b/schemas/iso19115-3/src/main/plugin/iso19115-3/layout/layout.xsl
@@ -44,12 +44,14 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="refToDelete" required="no"/>
+    <xsl:param name="isDisabled" required="no" />
 
     <xsl:apply-templates mode="mode-iso19115-3" select="*|@*">
       <xsl:with-param name="schema" select="$schema"/>
       <xsl:with-param name="labels" select="$labels"/>
       <xsl:with-param name="refToDelete" select="$refToDelete"/>
-    </xsl:apply-templates>
+      <xsl:with-param name="isDisabled" select="$isDisabled" />
+     </xsl:apply-templates>
   </xsl:template>
 
   <!-- Ignore all gn element -->
@@ -101,6 +103,7 @@
                         not(gco:CharacterString)]">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="isDisabled" required="no" />
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
@@ -130,14 +133,16 @@
       <xsl:with-param name="errors" select="$errors"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="isDisabled" select="$isDisabled"/>
       <xsl:with-param name="attributesSnippet" select="$attributes"/>
       <xsl:with-param name="subTreeSnippet">
         <!-- Process child of those element. Propagate schema
-        and labels to all subchilds (eg. needed like iso19110 elements
+        and labels to all sub-children (eg. needed like iso19110 elements
         contains gmd:* child. -->
         <xsl:apply-templates mode="mode-iso19115-3" select="*">
           <xsl:with-param name="schema" select="$schema"/>
           <xsl:with-param name="labels" select="$labels"/>
+          <xsl:with-param name="isDisabled" select="$isDisabled"/>
         </xsl:apply-templates>
       </xsl:with-param>
     </xsl:call-template>
@@ -445,6 +450,7 @@
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="codelists" select="$codelists" required="no"/>
     <xsl:param name="overrideLabel" select="''" required="no"/>
+    <xsl:param name="isDisabled" required="no" />
 
     <xsl:variable name="elementName" select="name()"/>
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
@@ -477,6 +483,7 @@
       <xsl:with-param name="listOfValues"
                       select="gn-fn-metadata:getCodeListValues($schema, name(*[@codeListValue]), $codelists, .)"/>
       <xsl:with-param name="isFirst" select="count(preceding-sibling::*[name() = $elementName]) = 0"/>
+      <xsl:with-param name="isDisabled" select="$isDisabled or count(ancestor-or-self::node()[@xlink:href]) > 0"/>
     </xsl:call-template>
   </xsl:template>
 


### PR DESCRIPTION
Once added a cited responsible or a contact the internal fields are not editable.
The user can still remove the contact and add contacts using the "Search for a contact"
widget.

Ref. GeoCat#537446

![image](https://user-images.githubusercontent.com/826920/87726882-2e244a80-c7c0-11ea-81d6-7feef7eaf848.png)
