### PR TITLE
Change the weights of fields in the search results

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -168,13 +168,13 @@
 
       //GA - To search by eCatId - start
       var regexp = /^\d+(?:(?:[\s])?[,](?:[\s])?\d+)+?$/;
-      if($scope.searchObj.params.any){
-        var iseCatIds = regexp.test($scope.searchObj.params.any);
-        if(iseCatIds){
+      if ($scope.searchObj.params.title_OR_altTitle_OR_any){
+        var iseCatIds = regexp.test($scope.searchObj.params.title_OR_altTitle_OR_any);
+        if (iseCatIds) {
           var eCatIdParam = {
-            eCatId: $scope.searchObj.params.any
+            eCatId: $scope.searchObj.params.title_OR_altTitle_OR_any
           }
-          delete $scope.searchObj.params.any;
+          delete $scope.searchObj.params.title_OR_altTitle_OR_any;
           angular.extend($scope.searchObj.params, eCatIdParam);
         }
       }
@@ -282,8 +282,11 @@
 
       // Add wildcard char to search, limit to subtemplates and the _root
       // element of the subtemplate we want
-      if (params.any) params.any = params.any + '*';
-      else params.any = '*';
+      if (params.title_OR_altTitle_OR_any) {
+        params.title_OR_altTitle_OR_any = params.title_OR_altTitle_OR_any + '*';
+      } else {
+        params.title_OR_altTitle_OR_any = '*';
+      }
 
       params._isTemplate = 's';
       params._root = element;

--- a/web-ui/src/main/resources/catalog/js/search/SearchController.js
+++ b/web-ui/src/main/resources/catalog/js/search/SearchController.js
@@ -251,7 +251,7 @@
        
          $scope.homeSearch = function(){
            var anytext = {
-             any : $scope.searchObj.params.any
+             title_OR_altTitle_OR_any : $scope.searchObj.params.title_OR_altTitle_OR_any
            }           
           $scope.$broadcast('resetSearch', anytext);             
         }

--- a/web-ui/src/main/resources/catalog/templates/admin/tools/batch.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/tools/batch.html
@@ -35,7 +35,7 @@
                 <input type="text"
                        class="form-control"
                        id="gn-any-field"
-                       data-ng-model="searchObj.params.any"
+                       data-ng-model="searchObj.params.title_OR_altTitle_OR_any"
                        data-ng-model-options="modelOptions"
                        placeholder="{{'anyPlaceHolder' | translate}}"
                        data-typeahead="address for address in getAnySuggestions($viewValue)"

--- a/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
@@ -142,7 +142,7 @@
                     <input type="text"
                            class="form-control"
                            id="gn-any-field"
-                           data-ng-model="searchObj.params.any"
+                           data-ng-model="searchObj.params.title_OR_altTitle_OR_any"
                            data-ng-model-options="modelOptions"
                            placeholder="{{'anyPlaceHolder' | translate}}"
                            data-typeahead="address for address in getAnySuggestions($viewValue)"

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -17,7 +17,7 @@
             <div class="sb_container_outer">
               <div class="input-group gn-any-search-input">
                 <input type="search" class="form-control input-md" id="gn-any-field"
-                  data-ng-model="searchObj.params.any" data-ng-model-options="modelOptions"
+                  data-ng-model="searchObj.params.title_OR_altTitle_OR_any" data-ng-model-options="modelOptions"
                   placeholder="{{'anyPlaceHolder' | translate}}"
                   data-ng-keyup="$event.keyCode == 13 && triggerSearch()" 
                   class="form-control" />

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -304,8 +304,14 @@
       }
 
       $scope.goToSearch = function (any) {
-        $location.path('/search').search({'any': any});
+        $location.path('/search').search({'title_OR_altTitle_OR_any': any});
       };
+
+      $scope.goToSearchFromEvent = function (event) {
+        $location.path('/search')
+            .search({'title_OR_altTitle_OR_any': event.currentTarget.value});
+      };
+
       $scope.canEdit = function(record) {
         // TODO: take catalog config for harvested records
         if (record && record['geonet:info'] &&

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -1,10 +1,10 @@
 <!-- Carousel -->
 <div class="container">
   <div class="home-container-outer">
-    <input type="search" class="form-control input-md" id="gn-any-field" data-ng-model="searchObj.params.any"
+    <input type="search" class="form-control input-md" id="gn-any-field" data-ng-model="searchObj.params.title_OR_altTitle_OR_any"
       data-ng-model-options="modelOptionsForm" 
       placeholder="Search..."
-      data-ng-keyup="$event.keyCode == 13 && triggerSearch()" 
+      data-ng-keyup="$event.keyCode == 13 && goToSearchFromEvent($event)"
       class="form-control" />
     <span>
       <button class="btn btn-lg searchbutton" type="button" data-ng-click="homeSearch()">

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -20,7 +20,7 @@
       <div class="new-filter">
         <div class="sb_container_outer">
           <div class="input-group gn-any-search-input">
-            <input type="search" class="form-control input-md" id="gn-any-field" data-ng-model="searchObj.params.any"
+            <input type="search" class="form-control input-md" id="gn-any-field" data-ng-model="searchObj.params.title_OR_altTitle_OR_any"
               data-ng-model-options="modelOptionsForm" placeholder="{{'anyPlaceHolder' | translate}}"
               data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
               class="form-control" />

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -12,7 +12,7 @@
             <input type="text"
                    class="form-control input-lg"
                    id="gn-any-field"
-                   data-ng-model="searchObj.params.any"
+                   data-ng-model="searchObj.params.title_OR_altTitle_OR_any"
                    data-ng-model-options="modelOptionsForm"
                    placeholder="{{'anyPlaceHolder' | translate}}"
                    data-ng-keyup="$event.keyCode == 13 && triggerSearch()"

--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -367,6 +367,10 @@
     <Field name="_dummy" boost="0.0F"/>
     <Field name="_isTemplate" boost="0.0F"/>
     <Field name="_owner" boost="0.0F"/>
+
+    <!-- GeoScience Australia custom search field weights  -->
+    <Field name="title" boost="1.8F" />
+    <Field name="altTitle" boost="1.25" />
   </fieldBoosting>
 
 


### PR DESCRIPTION
This PR boost the weight of `title` and `altTitle` fields in the search results.
In `config-lucene.xml` file `title` and `altTitle` fields have been added to the `fieldBoosting` section.

In the JS and HTML instead of using just the `any` field now the search is performed on `title OR altTitle OR any`.

Reference: GeoCat#2562.