### PR TITLE
API / Region / Return null.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
@@ -105,24 +105,6 @@ public class RegionsApi {
         Collection<RegionsDAO> daos =
             applicationContext.getBeansOfType(RegionsDAO.class).values();
 
-        long lastModified = -1;
-        for (RegionsDAO dao : daos) {
-            if (dao.includeInListing()) {
-                if (lastModified < Long.MAX_VALUE) {
-                    Request request = createRequest(label, categoryId, maxRecords, context, dao);
-
-                    Optional<Long> currentLastModified = request.getLastModified();
-                    if (currentLastModified.isPresent() && lastModified < currentLastModified.get()) {
-                        lastModified = currentLastModified.get();
-                    }
-                }
-            }
-        }
-
-        if (lastModified < Long.MAX_VALUE && webRequest.checkNotModified(lastModified)) {
-            return null;
-        }
-
         Collection<Region> regions = Lists.newArrayList();
         for (RegionsDAO dao : daos) {
             if (dao.includeInListing()) {


### PR DESCRIPTION
Client side cache is set up on angular app side. So we can rely on client side cache for this. 
No need for this check on server side - there is no similar behavior in the API.

Test:
* open https://vanilla.geocat.net/geonetwork/srv/api/regions?categoryId=http%3A%2F%2Fwww.naturalearthdata.com%2Fne_admin%23Country
* and reload (if browser cache is enabled, the content will be null)

This PR fixes _GeoCat#735223 - Metadata editor - geographic bounding box drop down list items not functioning_ issue.