### PR TITLE
[BP] Small improvements to the MiniMap: (geonetwork#5195)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/map/MapFieldDirective.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2020 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -78,35 +78,33 @@
                     scope.currentExtent = scope.$eval(scope.gnDrawBboxBtn);
                   });
 
-                  /**
-                   * Set active relation (intersect, within, etc..). Run search
-                   * when changed.
-                   */
-                  scope.setRelation = function(rel) {
-                    scope.searchObj.params.relation = rel;
-                    if (scope.autoTriggerSearch && !!scope.searchObj.params.geometry) {
-                      scope.triggerSearch();
-                    }
-                  };
-
-
-                  scope.renderMap = function() {
-                    scope.map.renderSync();
-                  };
-
-                  var loadPromise = scope.map.get('sizePromise');
-                  if (loadPromise) {
-                    loadPromise.then(function() {
-                      scope.renderMap();
-                    });
-                  }
-
+              /**
+               * Set active relation (intersect, within, etc..). Run search
+               * when changed.
+               */
+              scope.setRelation = function(rel) {
+                scope.searchObj.params.relation = rel;
+                if (scope.autoTriggerSearch && !!scope.searchObj.params.geometry) {
+                  scope.triggerSearch();
                 }
               };
+
+              scope.renderMap = function() {
+                scope.map.renderSync();
+              };
+
+              var loadPromise = scope.map.get('sizePromise');
+              if (loadPromise) {
+                loadPromise.then(function() {
+                  scope.renderMap();
+                });
+              }
             }
           };
         }
-      ])
+      };
+    }
+  ])
 
       .directive('gnDrawBboxBtn', [
         'olDecorateInteraction',

--- a/web-ui/src/main/resources/catalog/components/search/map/partials/mapfield.html
+++ b/web-ui/src/main/resources/catalog/components/search/map/partials/mapfield.html
@@ -10,6 +10,7 @@
     </button>-->
     <button data-ng-click="location.setMap()"
             data-ng-if="isMapViewerEnabled && !isExternalViewerEnabled"
+            type="button"
             title="{{'openLargeMap' | translate}}"
             aria-label="{{'openLargeMap' | translate}}"
             class="btn btn-default">
@@ -22,6 +23,7 @@
             gn-draw-bbox-btn="{{gnDrawBboxBtn}}"
             gn-draw-bbox-extent="{{gnDrawBboxExtent}}"
             gi-btn
+            type="button"
             title="{{getButtonTitle()}}"
             aria-label="{{getButtonTitle()}}"
             data-ng-class="{active: interaction.active}"
@@ -31,6 +33,7 @@
     </button>
     <button type="button"
             class="btn btn-default dropdown-toggle"
+            type="button"
             title="{{'chooseSpatialFilterType' | translate}}"
             aria-label="{{'chooseSpatialFilterType' | translate}}"
             data-toggle="dropdown"
@@ -62,6 +65,7 @@
           gn-draw-bbox-btn="{{gnDrawBboxBtn}}"
           gn-draw-bbox-extent="{{gnDrawBboxExtent}}"
           gi-btn
+          type="button"
           data-ng-model="interaction.active">
     <i class="fa fa-pencil"></i>
   </button>


### PR DESCRIPTION
Backport adds some (small) improvements to the mini map on the search page.

This solves the search on `eCatID` and other fields and the use of the `enter` key. Using the `enter` is **now** searching and not opening a full size map anymore.

The changes are:
- extra render option to prevent blank map on startup
- extra option to enable/disable direct search with extent
- add `type="button"` to minimap buttons to prevent accidental `goToMap` call
on `enter` click in the form

Backport of https://github.com/geonetwork/core-geonetwork/pull/5195